### PR TITLE
Propagate root cause to StoreException in case commit() throws

### DIFF
--- a/labencryptedstorage/src/main/java/mobi/lab/labencryptedstorage/impl/KeyValueStorageClearTextSharedPreferences.kt
+++ b/labencryptedstorage/src/main/java/mobi/lab/labencryptedstorage/impl/KeyValueStorageClearTextSharedPreferences.kt
@@ -47,25 +47,16 @@ public class KeyValueStorageClearTextSharedPreferences constructor(
         try {
             // Get a copy of the old data
             val oldDataJson = pref.getString(key, null)
-            val success: Boolean = try {
-                // Write the new one to storage it to storage
-                pref.edit().putString(key, dataJson).commit()
-            } catch (e: Throwable) {
-                false
-            }
-            if (!success) {
-                // Restore the memory cache value to the old one
-                try {
-                    pref.edit().putString(key, oldDataJson).commit()
-                } catch (e: Throwable) {
-                    // Ignore any and all errors from there
-                }
-                throw KeyValueStorageException.StoreException(appContext.getString(R.string.error_store_generic_1))
-            }
+            pref.commitForResult(key, dataJson)
+                .onFailure { pref.commitForResult(key, oldDataJson) }
+                .getOrThrow()
         } catch (e: Throwable) {
             throw KeyValueStorageException.StoreException(appContext.getString(R.string.error_store_generic_1), e)
         }
     }
+
+    private fun SharedPreferences.commitForResult(key: String, value: String?): Result<Boolean> =
+        runCatching { edit().putString(key, value).commit() }
 
     @Suppress("SwallowedException")
     override fun <T> read(key: String, valueType: Type): T? {


### PR DESCRIPTION
Fixes https://github.com/LabMobi/LabEncryptedStorage/issues/10

In the original code if first commit() throws then the root cause is ignored and not propagated to StoreException.

https://github.com/LabMobi/LabEncryptedStorage/blob/613c3e8cf8dd5ef280d0d29ce85a1dd2af547023/labencryptedstorage/src/main/java/mobi/lab/labencryptedstorage/impl/KeyValueStorageClearTextSharedPreferences.kt#L63

https://github.com/LabMobi/LabEncryptedStorage/blob/613c3e8cf8dd5ef280d0d29ce85a1dd2af547023/labencryptedstorage/src/main/java/mobi/lab/labencryptedstorage/impl/KeyValueStorageEncryptedSharedPreferences.kt#L75